### PR TITLE
Feature/cleanup on exit

### DIFF
--- a/src/main/java/com/palantir/curatortestrule/DefaultZooKeeperRuleConfig.java
+++ b/src/main/java/com/palantir/curatortestrule/DefaultZooKeeperRuleConfig.java
@@ -16,12 +16,19 @@
 
 package com.palantir.curatortestrule;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.io.Files;
 
@@ -32,6 +39,18 @@ import com.google.common.io.Files;
  * @author juang
  */
 public final class DefaultZooKeeperRuleConfig implements ZooKeeperRuleConfig {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LocalZooKeeperRule.class);
+
+    private final boolean cleanupOnExit;
+    private final Set<File> directoriesToCleanup = Collections.newSetFromMap(new ConcurrentHashMap());
+
+    public DefaultZooKeeperRuleConfig() {
+        this(false);
+    }
+
+    public DefaultZooKeeperRuleConfig(boolean cleanupOnExit) {
+        this.cleanupOnExit = cleanupOnExit;
+    }
 
     @Override
     public ServerCnxnFactory getServer(int port) {
@@ -39,7 +58,13 @@ public final class DefaultZooKeeperRuleConfig implements ZooKeeperRuleConfig {
 
         FileTxnSnapLog ftxn;
         try {
-            ftxn = new FileTxnSnapLog(Files.createTempDir(), Files.createTempDir());
+            File dataDir = Files.createTempDir();
+            File snapDir = Files.createTempDir();
+            if (cleanupOnExit) {
+                directoriesToCleanup.add(dataDir);
+                directoriesToCleanup.add(snapDir);
+            }
+            ftxn = new FileTxnSnapLog(dataDir, snapDir);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -56,4 +81,14 @@ public final class DefaultZooKeeperRuleConfig implements ZooKeeperRuleConfig {
         }
     }
 
+    @Override
+    public void cleanup() {
+        for (File dir : directoriesToCleanup) {
+           try {
+               FileUtils.deleteDirectory(dir);
+            } catch (IOException e) {
+                LOGGER.warn("Attempted to cleanup " + dir.getAbsolutePath() + " but cleanup failed.", e);
+            }
+        }
+    }
 }

--- a/src/main/java/com/palantir/curatortestrule/ZooKeeperRule.java
+++ b/src/main/java/com/palantir/curatortestrule/ZooKeeperRule.java
@@ -127,6 +127,8 @@ public abstract class ZooKeeperRule extends ExternalResource {
                 client.close();
             }
         }
+
+        ruleConfig.cleanup();
     }
 
     public static String generateRandomNamespace() {

--- a/src/main/java/com/palantir/curatortestrule/ZooKeeperRuleConfig.java
+++ b/src/main/java/com/palantir/curatortestrule/ZooKeeperRuleConfig.java
@@ -30,4 +30,5 @@ public interface ZooKeeperRuleConfig {
 
     ServerCnxnFactory getServer(int port);
 
+    void cleanup();
 }


### PR DESCRIPTION
By default, curator-test-rule leaves behind a lot of data in temp directories. Especially when using LocalZooKeeperRule, this can quickly fill up tmp.