### PR TITLE
Allow cleaning up the temp files on exit.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     compile "com.google.guava:guava:16.0.1"
     compile "org.slf4j:slf4j-api:1.7.6"
     compile "com.google.code.findbugs:jsr305:2.0.3"
+    compile "commons-io:commons-io:2.4"
 
     testRuntime "org.codehaus.groovy:groovy-all:2.1.6"
     testRuntime "ch.qos.logback:logback-classic:1.0.13"

--- a/src/main/java/com/palantir/curatortestrule/ZooKeeperRule.java
+++ b/src/main/java/com/palantir/curatortestrule/ZooKeeperRule.java
@@ -127,6 +127,8 @@ public abstract class ZooKeeperRule extends ExternalResource {
                 client.close();
             }
         }
+
+        ruleConfig.cleanup();
     }
 
     public static String generateRandomNamespace() {

--- a/src/main/java/com/palantir/curatortestrule/ZooKeeperRuleConfig.java
+++ b/src/main/java/com/palantir/curatortestrule/ZooKeeperRuleConfig.java
@@ -30,4 +30,5 @@ public interface ZooKeeperRuleConfig {
 
     ServerCnxnFactory getServer(int port);
 
+    void cleanup();
 }


### PR DESCRIPTION
By default, the server leaves relatively large files around in the temp directory. Especially when using a LocalZooKeeperRule, this can quickly fill up tmp space. This optionally allows the rule to clean up after itself.