### PR TITLE
Add external links to Javadocs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,18 @@ artifacts {
     archives sourcesJar
 }
 
+javadoc {
+    options {
+        links 'http://curator.apache.org/apidocs/',
+              'http://docs.oracle.com/javase/8/docs/api/',
+              'http://junit.org/javadoc/latest/',
+
+              // the normal ZK docs omit several server-side classes,
+              // including ones we use
+              'http://people.apache.org/~larsgeorge/zookeeper-1075002/build/docs/dev-api/'
+    }
+}
+
 signing {
     required { gradle.taskGraph.hasTask(":uploadArchives") }
     sign configurations.archives


### PR DESCRIPTION
Allows readers to navigate to docs for third-party library classes easily. See http://punya.github.io/curator-test-rule/javadoc/com/palantir/curatortestrule/ZooKeeperRule.html for an example of the result.