### PR TITLE
ensure that clients are closed before the server is closed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 .classpath
 .project
 .settings/
+.idea/
+*.iml
 
 /bin
 /build

--- a/src/main/java/com/palantir/curatortestrule/LocalZooKeeperRule.java
+++ b/src/main/java/com/palantir/curatortestrule/LocalZooKeeperRule.java
@@ -67,22 +67,18 @@ public final class LocalZooKeeperRule extends ZooKeeperRule {
     }
 
     @Override
-    protected void after() {
-        super.closeClients();
+    protected void closeServer() {
         if (this.cnxnFactory != null) {
             LOGGER.debug("Closing ZooKeeper server at port {}", this.cnxnFactory.getLocalPort());
-
             this.cnxnFactory.shutdown();
         } else {
             LOGGER.debug("Cannot close ZooKeeper server. It is likely that it had trouble starting.");
         }
-        super.after();
     }
 
     @Override
     protected ServerCnxnFactory getCnxnFactory() {
         Preconditions.checkState(this.cnxnFactory != null);
-
         return this.cnxnFactory;
     }
 }

--- a/src/main/java/com/palantir/curatortestrule/LocalZooKeeperRule.java
+++ b/src/main/java/com/palantir/curatortestrule/LocalZooKeeperRule.java
@@ -68,6 +68,7 @@ public final class LocalZooKeeperRule extends ZooKeeperRule {
 
     @Override
     protected void after() {
+        super.closeClients();
         if (this.cnxnFactory != null) {
             LOGGER.debug("Closing ZooKeeper server at port {}", this.cnxnFactory.getLocalPort());
 
@@ -75,7 +76,6 @@ public final class LocalZooKeeperRule extends ZooKeeperRule {
         } else {
             LOGGER.debug("Cannot close ZooKeeper server. It is likely that it had trouble starting.");
         }
-
         super.after();
     }
 

--- a/src/main/java/com/palantir/curatortestrule/SharedZooKeeperRule.java
+++ b/src/main/java/com/palantir/curatortestrule/SharedZooKeeperRule.java
@@ -74,18 +74,13 @@ public final class SharedZooKeeperRule extends ZooKeeperRule {
     }
 
     @Override
-    protected void after() {
-        super.closeClients();
-
+    protected void closeServer() {
         if (this.cnxnFactory != null) {
             LOGGER.debug("Closing ZooKeeper server at port {}", this.cnxnFactory.getLocalPort());
-
             SHARED_SERVER_MANAGER.releaseServer(port);
         } else {
             LOGGER.debug("Cannot close ZooKeeper server. It is likely that it had trouble starting.");
         }
-
-        super.after();
     }
 
     @Override

--- a/src/main/java/com/palantir/curatortestrule/SharedZooKeeperRule.java
+++ b/src/main/java/com/palantir/curatortestrule/SharedZooKeeperRule.java
@@ -75,6 +75,8 @@ public final class SharedZooKeeperRule extends ZooKeeperRule {
 
     @Override
     protected void after() {
+        super.closeClients();
+
         if (this.cnxnFactory != null) {
             LOGGER.debug("Closing ZooKeeper server at port {}", this.cnxnFactory.getLocalPort());
 

--- a/src/main/java/com/palantir/curatortestrule/ZooKeeperRule.java
+++ b/src/main/java/com/palantir/curatortestrule/ZooKeeperRule.java
@@ -120,15 +120,16 @@ public abstract class ZooKeeperRule extends ExternalResource {
 
     @Override
     protected void after() {
-        LOGGER.debug("Closing {} curator clients", curatorClients.size());
+        ruleConfig.cleanup();
+    }
 
+    protected void closeClients() {
+        LOGGER.debug("Closing {} curator clients", curatorClients.size());
         for (CuratorFramework client : curatorClients) {
             if (client.getState() == CuratorFrameworkState.STARTED) {
                 client.close();
             }
         }
-
-        ruleConfig.cleanup();
     }
 
     public static String generateRandomNamespace() {

--- a/src/main/java/com/palantir/curatortestrule/ZooKeeperRule.java
+++ b/src/main/java/com/palantir/curatortestrule/ZooKeeperRule.java
@@ -120,6 +120,8 @@ public abstract class ZooKeeperRule extends ExternalResource {
 
     @Override
     protected void after() {
+        closeClients();
+        closeServer();
         ruleConfig.cleanup();
     }
 
@@ -131,6 +133,8 @@ public abstract class ZooKeeperRule extends ExternalResource {
             }
         }
     }
+
+    protected abstract void closeServer();
 
     public static String generateRandomNamespace() {
         return UUID.randomUUID().toString();


### PR DESCRIPTION
I notice these types of errors in my test code, and tracked it down to the fact that the server instance was being closed prior to the client instances. This change seems to fix the issue and cuts down on a lot of logging chatter, plus enables my tests to run much faster.

```
18:22:44.810 [main-SendThread(127.0.0.1:9500)] DEBUG org.apache.zookeeper.ClientCnxn - Reading reply sessionid:0x1523c3990e40006, packet:: clientPath:/kafka/brokers/topics serverPath:/kafka/brokers/topics finished:false header:: 1882,12  replyHeader:: 1882,402,-101  request:: '/kafka/brokers/topics,T  response:: v{} 
18:22:44.813 [main-SendThread(127.0.0.1:9500)] INFO  org.apache.zookeeper.ClientCnxn - Unable to read additional data from server sessionid 0x1523c3990e40012, likely server has closed socket, closing socket connection and attempting reconnect
18:22:44.814 [main] INFO  o.a.zookeeper.server.NIOServerCnxn - Closed socket connection for client /127.0.0.1:58794 which had sessionid 0x1523c3990e40017
18:22:44.814 [main-SendThread(127.0.0.1:9500)] INFO  org.apache.zookeeper.ClientCnxn - Unable to read additional data from server sessionid 0x1523c3990e40017, likely server has closed socket, closing socket connection and attempting reconnect
```
